### PR TITLE
Added support for find_package.

### DIFF
--- a/CONSUMING.md
+++ b/CONSUMING.md
@@ -1,0 +1,20 @@
+# IO2D Consuming How-To
+
+First, you need to build and install this library somewhere where it will be found using `find_package`. Then, add the following line to import the targets into your CMake build script:
+
+	find_package(io2d REQUIRED)
+
+Then you can choose which target to link your app to. The most reasonable choice is to link to `io2d::io2d`:
+
+	target_link_libraries(ExampleApp PRIVATE io2d::io2d)
+
+This will link to backends that were built. This will make your app cross-platform out of the box. If you want to link to specific backend, you can specify it, for example:
+
+	target_link_libraries(ExampleApp PRIVATE io2d::io2d_cairo_xlib)
+
+This will link to Cairo/Xlib backend only. Available backends are:
+
+* `io2d::io2d_cairo_win32`
+* `io2d::io2d_cairo_xlib`
+* `io2d::io2d_coregraphics_mac`
+* `io2d::io2d_coregraphics_ios`

--- a/P0267_RefImpl/P0267_RefImpl/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.8)
 project(io2d CXX)
-set(CMAKE_CXX_STANDARD 17)
 
 # If there's no default backend we try to set it automatically
 if( NOT DEFINED IO2D_DEFAULT )
@@ -24,7 +23,11 @@ if( NOT DEFINED IO2D_ENABLED )
 	set(IO2D_ENABLED ${IO2D_DEFAULT})
 endif()
 
-add_library(io2d
+# Core library
+# io2d_core contains backend-independent files. It is used by backends. You
+# shouldn't directly link to this library.
+
+add_library(io2d_core
 	rgba_color.cpp
 	xio2d.h
 	xbrushes.h
@@ -50,24 +53,53 @@ add_library(io2d
     xinterchangebuffer.h
 )
 
-target_include_directories(io2d PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
+target_include_directories(io2d_core PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+target_compile_features(io2d_core PUBLIC cxx_std_17)
+
+install(
+	TARGETS io2d_core EXPORT io2d_targets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+file(
+	GLOB IO2D_CORE_HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+)
+
+install(
+	FILES ${IO2D_CORE_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# User facing library
+# io2d is a user facing interface library that depends on all enabled backends
+# Usually, you want to link only to this library.
+
+add_library(io2d INTERFACE)
 
 # function that maps a backend name into it's path and library name
 function(GET_BACKEND_INFO backend_name)
 	if( ${backend_name} STREQUAL "COREGRAPHICS_MAC" )
-		set(BACKEND_PATH coregraphics/mac PARENT_SCOPE)
+		set(BACKEND_PATH1 coregraphics PARENT_SCOPE)
+		set(BACKEND_PATH2 coregraphics/mac PARENT_SCOPE)
 		set(BACKEND_LIBRARY io2d_coregraphics_mac PARENT_SCOPE)
 	elseif( ${backend_name} STREQUAL "COREGRAPHICS_IOS" )
-		set(BACKEND_PATH coregraphics/ios PARENT_SCOPE)
+		set(BACKEND_PATH1 coregraphics PARENT_SCOPE)
+		set(BACKEND_PATH2 coregraphics/ios PARENT_SCOPE)
 		set(BACKEND_LIBRARY io2d_coregraphics_ios PARENT_SCOPE)
 	elseif( ${backend_name} STREQUAL "CAIRO_XLIB" )
-		set(BACKEND_PATH cairo/xlib PARENT_SCOPE)
+		set(BACKEND_PATH1 cairo PARENT_SCOPE)
+		set(BACKEND_PATH2 cairo/xlib PARENT_SCOPE)
 		set(BACKEND_LIBRARY io2d_cairo_xlib PARENT_SCOPE)
 	elseif( ${backend_name} STREQUAL "CAIRO_WIN32" )
-		set(BACKEND_PATH cairo/win32 PARENT_SCOPE)
+		set(BACKEND_PATH1 cairo PARENT_SCOPE)
+		set(BACKEND_PATH2 cairo/win32 PARENT_SCOPE)
 		set(BACKEND_LIBRARY io2d_cairo_win32 PARENT_SCOPE)
 	else()
 		message( FATAL_ERROR "GET_BACKEND_INFO: unknown backend name" )
@@ -77,31 +109,18 @@ endfunction(GET_BACKEND_INFO)
 # fetch info about the default backend
 GET_BACKEND_INFO(${IO2D_DEFAULT})
 
-# add a search path depending on a default backend setting
-target_include_directories(io2d PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/${BACKEND_PATH}
-)
-
 # add backends themselves
 foreach(backend ${IO2D_ENABLED})
 	GET_BACKEND_INFO(${backend})
-	add_subdirectory(${BACKEND_PATH})
-	target_link_libraries(io2d ${BACKEND_LIBRARY})
+	add_subdirectory(${BACKEND_PATH1})
+	add_subdirectory(${BACKEND_PATH2})
+	target_link_libraries(io2d INTERFACE ${BACKEND_LIBRARY})
 endforeach(backend)
 
-# installation
-install(
-    TARGETS io2d
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-file(
-    GLOB IO2D_HEADERS
-    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
-)
+install(TARGETS io2d EXPORT io2d_targets)
 
-install(
-    FILES ${IO2D_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+install(EXPORT io2d_targets
+	FILE io2dConfig.cmake
+	NAMESPACE io2d::
+	DESTINATION lib/cmake/io2d
 )

--- a/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(io2d CXX)
+
+add_library(io2d_cairo
+	cairo_renderer-graphicsmagickinit.cpp
+	xcairo.h
+	xcairo_brushes_impl.h
+	xcairo_helpers.h
+	xcairo_paths_impl.h
+	xcairo_surfaces_image_impl.h
+	xcairo_surfaces_impl.h
+	xcairo_surface_state_props_impl.h
+	xio2d_cairo_main.h
+)
+
+target_include_directories(io2d_cairo PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(io2d_cairo PUBLIC cxx_std_17)
+
+target_link_libraries(io2d_cairo PUBLIC io2d_core)
+
+if(MSVC)
+	find_path(CAIRO_INCLUDE_DIR cairo.h)
+	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h)
+	find_library(CAIRO_LIB_DEBUG cairod)
+	find_library(CAIRO_LIB_RELEASE cairo)
+	find_library(GRAPHICSMAGICK_LIB graphicsmagick)
+elseif(APPLE)
+	find_path(CAIRO_INCLUDE_DIR cairo-xlib.h PATH_SUFFIXES cairo)
+	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h PATH_SUFFIXES GraphicsMagick)
+	find_library(CAIRO_LIB cairo)
+	find_library(GRAPHICSMAGICK_LIB GraphicsMagick)
+else() # Linux
+	find_path(CAIRO_INCLUDE_DIR cairo-xlib.h PATH_SUFFIXES cairo)
+	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h PATH_SUFFIXES GraphicsMagick)
+	find_library(CAIRO_LIB cairo)
+	find_library(GRAPHICSMAGICK_LIB GraphicsMagick)
+endif()
+
+target_include_directories(io2d_cairo SYSTEM PUBLIC ${CAIRO_INCLUDE_DIR} ${GRAPHICSMAGICK_INCLUDE_DIR})
+
+target_link_libraries(io2d_cairo PUBLIC ${GRAPHICSMAGICK_LIB})
+
+if(MSVC)
+	target_link_libraries(io2d_cairo PUBLIC debug ${CAIRO_LIB_DEBUG} optimized ${CAIRO_LIB_RELEASE})
+else()
+	target_link_libraries(io2d_cairo PUBLIC ${CAIRO_LIB})
+endif()
+
+install(
+	TARGETS io2d_cairo EXPORT io2d_targets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+file(
+	GLOB IO2D_CAIRO_HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+)
+
+install(
+	FILES ${IO2D_CAIRO_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/P0267_RefImpl/P0267_RefImpl/cairo/cairo_renderer-graphicsmagickinit.cpp
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/cairo_renderer-graphicsmagickinit.cpp
@@ -1,4 +1,3 @@
-#include "io2d.h"
 #include "xcairo.h"
 #include <mutex>
 #include <magick/api.h>

--- a/P0267_RefImpl/P0267_RefImpl/cairo/win32/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/win32/CMakeLists.txt
@@ -41,9 +41,9 @@ if(MSVC)
 	find_library(ICONV_LIB libiconv)
 	find_library(CHARSET_LIB libcharset)
 
-	target_link_libraries(io2d_cairo_win32 ${PIXMAN_LIB} ${FREETYPE_LIB} ${FONTCONFIG_LIB} ${BZ_LIB} ${JPEG_LIB} ${TIFF_LIB} ${EXPAT_LIB} ${LZMA_LIB} ${ICONV_LIB} ${CHARSET_LIB})
-	target_link_libraries(io2d_cairo_win32 debug ${PNG_LIB_DEBUG} optimized ${PNG_LIB_RELEASE})
-	target_link_libraries(io2d_cairo_win32 debug ${ZLIB_LIB_DEBUG} optimized ${ZLIB_LIB_RELEASE})
+	target_link_libraries(io2d_cairo_win32 PUBLIC ${PIXMAN_LIB} ${FREETYPE_LIB} ${FONTCONFIG_LIB} ${BZ_LIB} ${JPEG_LIB} ${TIFF_LIB} ${EXPAT_LIB} ${LZMA_LIB} ${ICONV_LIB} ${CHARSET_LIB})
+	target_link_libraries(io2d_cairo_win32 PUBLIC debug ${PNG_LIB_DEBUG} optimized ${PNG_LIB_RELEASE})
+	target_link_libraries(io2d_cairo_win32 PUBLIC debug ${ZLIB_LIB_DEBUG} optimized ${ZLIB_LIB_RELEASE})
 endif()
  
 install(

--- a/P0267_RefImpl/P0267_RefImpl/cairo/win32/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/win32/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(io2d CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-
-set(IO2D_LIB_SRC 
+add_library(io2d_cairo_win32 
 	io2d.h
 	io2d_cairo_win32.h
 	xio2d_cairo_win32_main.h
@@ -14,33 +12,20 @@ set(IO2D_LIB_SRC
 	xio2d_cairo_win32_surfaces_impl.h
 	xio2d_cairo_win32_error.h
 	cairo_renderer_win32.cpp
-	../xcairo.h
-	../xcairo_brushes_impl.h
-	../xcairo_helpers.h
-	../xcairo_paths_impl.h
-	../xcairo_surface_state_props_impl.h
-	../xcairo_surfaces_image_impl.h
-	../xcairo_surfaces_impl.h
-	../xio2d_cairo_main.h
-	../cairo_renderer-graphicsmagickinit.cpp
 )
-
-add_library(io2d_cairo_win32 ${IO2D_LIB_SRC})
 
 target_include_directories(io2d_cairo_win32 PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/..
-  ${CMAKE_CURRENT_SOURCE_DIR}/../..
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+target_compile_features(io2d_cairo_win32 PUBLIC cxx_std_17)
+
+target_link_libraries(io2d_cairo_win32 PUBLIC io2d_cairo)
  
 if(MSVC)
 	target_compile_definitions(io2d_cairo_win32 PUBLIC -DUNICODE -D_UNICODE -D_CRT_SECURE_NO_WARNINGS)
 
-	find_path(CAIRO_INCLUDE_DIR cairo.h)
-	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h)
-	find_library(CAIRO_LIB_DEBUG cairod)
-	find_library(CAIRO_LIB_RELEASE cairo)
-	find_library(GRAPHICSMAGICK_LIB graphicsmagick)
 	find_library(PIXMAN_LIB pixman-1)
 	find_library(FREETYPE_LIB freetype)
 	find_library(FONTCONFIG_LIB fontconfig)
@@ -56,26 +41,24 @@ if(MSVC)
 	find_library(ICONV_LIB libiconv)
 	find_library(CHARSET_LIB libcharset)
 
-	target_include_directories(io2d_cairo_win32 PUBLIC ${CAIRO_INCLUDE_DIR} ${GRAPHICSMAGICK_INCLUDE_DIR})
-	target_link_libraries(io2d_cairo_win32 ${GRAPHICSMAGICK_LIB} ${PIXMAN_LIB} ${FREETYPE_LIB} ${FONTCONFIG_LIB} ${BZ_LIB} ${JPEG_LIB} ${TIFF_LIB} ${EXPAT_LIB} ${LZMA_LIB} ${ICONV_LIB} ${CHARSET_LIB})
+	target_link_libraries(io2d_cairo_win32 ${PIXMAN_LIB} ${FREETYPE_LIB} ${FONTCONFIG_LIB} ${BZ_LIB} ${JPEG_LIB} ${TIFF_LIB} ${EXPAT_LIB} ${LZMA_LIB} ${ICONV_LIB} ${CHARSET_LIB})
 	target_link_libraries(io2d_cairo_win32 debug ${PNG_LIB_DEBUG} optimized ${PNG_LIB_RELEASE})
 	target_link_libraries(io2d_cairo_win32 debug ${ZLIB_LIB_DEBUG} optimized ${ZLIB_LIB_RELEASE})
-	target_link_libraries(io2d_cairo_win32 debug ${CAIRO_LIB_DEBUG} optimized ${CAIRO_LIB_RELEASE})
 endif()
  
-# installation
 install(
-    TARGETS io2d_cairo_win32
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	TARGETS io2d_cairo_win32 EXPORT io2d_targets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
 file(
-    GLOB IO2D_HEADERS
-    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../*.h"
+	GLOB IO2D_CAIRO_WIN32_HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
+
 install(
-    FILES ${IO2D_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	FILES ${IO2D_CAIRO_WIN32_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/P0267_RefImpl/P0267_RefImpl/cairo/xlib/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/xlib/CMakeLists.txt
@@ -1,47 +1,30 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(io2d CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-
-set(IO2D_LIB_SRC
-   	io2d.h
-    io2d_cairo_xlib.h
+add_library(io2d_cairo_xlib
 	cairo_renderer_xlib.cpp
-    xio2d_cairo_xlib_main.h
+	io2d.h
+	io2d_cairo_xlib.h
+	xio2d_cairo_xlib_main.h
 	xio2d_cairo_xlib_output_surfaces.h
-	xio2d_cairo_xlib_unmanaged_output_surfaces.h
 	xio2d_cairo_xlib_surfaces.h
-   	xio2d_cairo_xlib_surfaces_impl.h
-	../xio2d_cairo_main.h
-	../xcairo.h
-	../xcairo_brushes_impl.h
-	../xcairo_helpers.h
-	../xcairo_paths_impl.h
-	../xcairo_surface_state_props_impl.h
-	../xcairo_surfaces_image_impl.h
-	../xcairo_surfaces_impl.h
-	../cairo_renderer-graphicsmagickinit.cpp
-    ../../xpath.h
-    ../../xpath_impl.h
-    ../../xpathbuilder_impl.h
+	xio2d_cairo_xlib_surfaces_impl.h
+	xio2d_cairo_xlib_unmanaged_output_surfaces.h
 )
-
-add_library(io2d_cairo_xlib ${IO2D_LIB_SRC})
 
 target_include_directories(io2d_cairo_xlib PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/..
-  ${CMAKE_CURRENT_SOURCE_DIR}/../..
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+target_compile_features(io2d_cairo_xlib PUBLIC cxx_std_17)
+
+target_link_libraries(io2d_cairo_xlib PUBLIC io2d_cairo)
 
 if(MSVC)
 # TODO?
 elseif(APPLE)
-	find_path(CAIRO_INCLUDE_DIR cairo-xlib.h PATH_SUFFIXES cairo)
-	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h PATH_SUFFIXES GraphicsMagick)
-	find_library(CAIRO_LIB cairo)
-	find_library(GRAPHICSMAGICK_LIB GraphicsMagick)
 	find_library(PIXMAN_LIB pixman-1)
 	find_library(FREETYPE_LIB freetype)
 	find_library(FONTCONFIG_LIB fontconfig)
@@ -56,10 +39,6 @@ elseif(APPLE)
 	find_library(CHARSET_LIB charset)
     find_library(X11_LIB X11)
 else() # Linux
-	find_path(CAIRO_INCLUDE_DIR cairo-xlib.h PATH_SUFFIXES cairo)
-	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h PATH_SUFFIXES GraphicsMagick)
-	find_library(CAIRO_LIB cairo)
-	find_library(GRAPHICSMAGICK_LIB GraphicsMagick)
 	find_library(PIXMAN_LIB pixman-1)
 	find_library(FREETYPE_LIB freetype)
 	find_library(FONTCONFIG_LIB fontconfig)
@@ -75,21 +54,21 @@ else() # Linux
 	set(CHARSET_LIB "")
 endif()
 
-target_include_directories(io2d_cairo_xlib SYSTEM PUBLIC ${CAIRO_INCLUDE_DIR} ${GRAPHICSMAGICK_INCLUDE_DIR})
-target_link_libraries(io2d_cairo_xlib ${CAIRO_LIB} ${GRAPHICSMAGICK_LIB} ${PIXMAN_LIB} ${FREETYPE_LIB} ${FONTCONFIG_LIB} ${BZ_LIB} ${ZLIB_LIB} ${JPEG_LIB} ${PNG_LIB} ${TIFF_LIB} ${EXPAT_LIB} ${LZMA_LIB} ${ICONV_LIB} ${CHARSET_LIB} ${X11_LIB})
+target_link_libraries(io2d_cairo_xlib PUBLIC ${PIXMAN_LIB} ${FREETYPE_LIB} ${FONTCONFIG_LIB} ${BZ_LIB} ${ZLIB_LIB} ${JPEG_LIB} ${PNG_LIB} ${TIFF_LIB} ${EXPAT_LIB} ${LZMA_LIB} ${ICONV_LIB} ${CHARSET_LIB} ${X11_LIB})
 
 install(
-    TARGETS io2d_cairo_xlib
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	TARGETS io2d_cairo_xlib EXPORT io2d_targets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
 file(
-    GLOB IO2D_HEADERS
-    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../*.h"
+	GLOB IO2D_CAIRO_XLIB_HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
+
 install(
-    FILES ${IO2D_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	FILES ${IO2D_CAIRO_XLIB_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/P0267_RefImpl/P0267_RefImpl/coregraphics/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/coregraphics/CMakeLists.txt
@@ -37,9 +37,9 @@ target_compile_features(io2d_coregraphics PUBLIC cxx_std_17)
 
 target_link_libraries(io2d_coregraphics PUBLIC io2d_core)
 
-target_link_libraries(io2d_coregraphics "-framework CoreFoundation")
-target_link_libraries(io2d_coregraphics "-framework ImageIO")
-target_link_libraries(io2d_coregraphics "-framework CoreGraphics")
+target_link_libraries(io2d_coregraphics PUBLIC "-framework CoreFoundation")
+target_link_libraries(io2d_coregraphics PUBLIC "-framework ImageIO")
+target_link_libraries(io2d_coregraphics PUBLIC "-framework CoreGraphics")
 
 install(
 	TARGETS io2d_coregraphics EXPORT io2d_targets

--- a/P0267_RefImpl/P0267_RefImpl/coregraphics/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/coregraphics/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(io2d CXX)
+
+add_library(io2d_coregraphics
+	xio2d_cg_brushes.cpp
+	xio2d_cg_brushes.h
+	xio2d_cg_colors.cpp
+	xio2d_cg_colors.h
+	xio2d_cg_display.cpp
+	xio2d_cg_display.h
+	xio2d_cg_fps_counter.cpp
+	xio2d_cg_fps_counter.h
+	xio2d_cg_gradient.cpp
+	xio2d_cg_gradient.h
+	xio2d_cg_interop.h
+	xio2d_cg_main.h
+	xio2d_cg_paths.cpp
+	xio2d_cg_paths.h
+	xio2d_cg_paths_figures.cpp
+	xio2d_cg_paths_figures.h
+	xio2d_cg_surfaces.cpp
+	xio2d_cg_surfaces.h
+	xio2d_cg_surface_state_props.h
+	xio2d_cg_texture.cpp
+	xio2d_cg_texture.h
+	xio2d_cg_tmplayer.cpp
+	xio2d_cg_tmplayer.h
+)
+
+target_include_directories(io2d_coregraphics PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(io2d_coregraphics PUBLIC cxx_std_17)
+
+target_link_libraries(io2d_coregraphics PUBLIC io2d_core)
+
+target_link_libraries(io2d_coregraphics "-framework CoreFoundation")
+target_link_libraries(io2d_coregraphics "-framework ImageIO")
+target_link_libraries(io2d_coregraphics "-framework CoreGraphics")
+
+install(
+	TARGETS io2d_coregraphics EXPORT io2d_targets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+file(
+	GLOB IO2D_COREGRAPHICS_HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+)
+
+install(
+	FILES ${IO2D_COREGRAPHICS_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/P0267_RefImpl/P0267_RefImpl/coregraphics/ios/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/coregraphics/ios/CMakeLists.txt
@@ -18,9 +18,9 @@ target_compile_features(io2d_coregraphics_ios PUBLIC cxx_std_17)
 
 target_link_libraries(io2d_coregraphics_ios PUBLIC io2d_coregraphics)
 
-target_link_libraries(io2d_coregraphics_ios "-framework UIKit")
-target_link_libraries(io2d_coregraphics_ios "-framework Foundation")
-target_link_libraries(io2d_coregraphics_ios "-framework QuartzCore")
+target_link_libraries(io2d_coregraphics_ios PUBLIC "-framework UIKit")
+target_link_libraries(io2d_coregraphics_ios PUBLIC "-framework Foundation")
+target_link_libraries(io2d_coregraphics_ios PUBLIC "-framework QuartzCore")
 
 install(
 	TARGETS io2d_coregraphics_ios EXPORT io2d_targets

--- a/P0267_RefImpl/P0267_RefImpl/coregraphics/ios/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/coregraphics/ios/CMakeLists.txt
@@ -1,48 +1,40 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(io2d CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-
-set(IO2D_LIB_SRC 
+add_library(io2d_coregraphics_ios
 	io2d.h
 	io2d_coregraphics_ios.h
-    xio2d_cg_output_surfaces.h
-    xio2d_cg_output_surfaces.mm
-	../xio2d_cg_main.h
-	../xio2d_cg_brushes.h
-	../xio2d_cg_brushes.cpp
-	../xio2d_cg_interop.h
-	../xio2d_cg_paths.h
-	../xio2d_cg_paths.cpp
-	../xio2d_cg_surface_state_props.h
-	../xio2d_cg_paths_figures.h
-	../xio2d_cg_paths_figures.cpp
-	../xio2d_cg_surfaces.h
-	../xio2d_cg_surfaces.cpp
-   	../xio2d_cg_gradient.cpp
-    ../xio2d_cg_gradient.h
-	../xio2d_cg_colors.cpp
-	../xio2d_cg_colors.h
-	../xio2d_cg_texture.cpp
-	../xio2d_cg_texture.h
-	../xio2d_cg_fps_counter.cpp
-	../xio2d_cg_fps_counter.h
-    ../xio2d_cg_display.cpp
-    ../xio2d_cg_display.h
+	xio2d_cg_output_surfaces.h
+	xio2d_cg_output_surfaces.mm
 )
-
-add_library(io2d_coregraphics_ios ${IO2D_LIB_SRC})
 
 target_include_directories(io2d_coregraphics_ios PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/..
-  ${CMAKE_CURRENT_SOURCE_DIR}/../..
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+target_compile_features(io2d_coregraphics_ios PUBLIC cxx_std_17)
+
+target_link_libraries(io2d_coregraphics_ios PUBLIC io2d_coregraphics)
 
 target_link_libraries(io2d_coregraphics_ios "-framework UIKit")
 target_link_libraries(io2d_coregraphics_ios "-framework Foundation")
-target_link_libraries(io2d_coregraphics_ios "-framework CoreFoundation")
-target_link_libraries(io2d_coregraphics_ios "-framework ImageIO")
-target_link_libraries(io2d_coregraphics_ios "-framework CoreGraphics")
 target_link_libraries(io2d_coregraphics_ios "-framework QuartzCore")
+
+install(
+	TARGETS io2d_coregraphics_ios EXPORT io2d_targets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+file(
+	GLOB IO2D_COREGRAPHICS_IOS_HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+)
+
+install(
+	FILES ${IO2D_COREGRAPHICS_IOS_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/P0267_RefImpl/P0267_RefImpl/coregraphics/mac/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/coregraphics/mac/CMakeLists.txt
@@ -1,67 +1,40 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(io2d CXX)
 
-set(CMAKE_CXX_STANDARD 17)
-
-set(IO2D_LIB_SRC 
+add_library(io2d_coregraphics_mac
 	io2d.h
 	io2d_coregraphics_mac.h
-    xio2d_cg_output_surfaces.h
-    xio2d_cg_output_surfaces.mm
-	../xio2d_cg_main.h
-	../xio2d_cg_brushes.h
-	../xio2d_cg_brushes.cpp
-	../xio2d_cg_interop.h
-	../xio2d_cg_paths.h
-	../xio2d_cg_paths.cpp
-	../xio2d_cg_surface_state_props.h
-	../xio2d_cg_paths_figures.h
-	../xio2d_cg_paths_figures.cpp
-	../xio2d_cg_surfaces.h
-	../xio2d_cg_surfaces.cpp
-    ../xio2d_cg_gradient.cpp
-    ../xio2d_cg_gradient.h
-    ../xio2d_cg_colors.cpp
-    ../xio2d_cg_colors.h
-    ../xio2d_cg_texture.cpp
-    ../xio2d_cg_texture.h
-	../xio2d_cg_fps_counter.cpp
-	../xio2d_cg_fps_counter.h
-    ../xio2d_cg_display.cpp
-    ../xio2d_cg_display.h
-    ../xio2d_cg_tmplayer.cpp
-    ../xio2d_cg_tmplayer.h
+	xio2d_cg_output_surfaces.h
+	xio2d_cg_output_surfaces.mm
 )
-
-add_library(io2d_coregraphics_mac ${IO2D_LIB_SRC})
 
 target_include_directories(io2d_coregraphics_mac PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/..
-  ${CMAKE_CURRENT_SOURCE_DIR}/../..
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+target_compile_features(io2d_coregraphics_mac PUBLIC cxx_std_17)
+
+target_link_libraries(io2d_coregraphics_mac PUBLIC io2d_coregraphics)
 
 target_link_libraries(io2d_coregraphics_mac "-framework Cocoa")
 target_link_libraries(io2d_coregraphics_mac "-framework AppKit")
 target_link_libraries(io2d_coregraphics_mac "-framework CoreServices")
-target_link_libraries(io2d_coregraphics_mac "-framework CoreFoundation")
-target_link_libraries(io2d_coregraphics_mac "-framework ImageIO")
-target_link_libraries(io2d_coregraphics_mac "-framework CoreGraphics")
 
-# installation
 install(
-    TARGETS io2d_coregraphics_mac
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	TARGETS io2d_coregraphics_mac EXPORT io2d_targets
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
 file(
-    GLOB IO2D_HEADERS
-    "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../*.h"
+	GLOB IO2D_COREGRAPHICS_MAC_HEADERS
+	"${CMAKE_CURRENT_SOURCE_DIR}/*.h"
 )
+
 install(
-    FILES ${IO2D_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	FILES ${IO2D_COREGRAPHICS_MAC_HEADERS}
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/P0267_RefImpl/P0267_RefImpl/coregraphics/mac/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/coregraphics/mac/CMakeLists.txt
@@ -18,9 +18,9 @@ target_compile_features(io2d_coregraphics_mac PUBLIC cxx_std_17)
 
 target_link_libraries(io2d_coregraphics_mac PUBLIC io2d_coregraphics)
 
-target_link_libraries(io2d_coregraphics_mac "-framework Cocoa")
-target_link_libraries(io2d_coregraphics_mac "-framework AppKit")
-target_link_libraries(io2d_coregraphics_mac "-framework CoreServices")
+target_link_libraries(io2d_coregraphics_mac PUBLIC "-framework Cocoa")
+target_link_libraries(io2d_coregraphics_mac PUBLIC "-framework AppKit")
+target_link_libraries(io2d_coregraphics_mac PUBLIC "-framework CoreServices")
 
 install(
 	TARGETS io2d_coregraphics_mac EXPORT io2d_targets

--- a/P0267_RefImpl/P0267_RefImpl/coregraphics/xio2d_cg_main.h
+++ b/P0267_RefImpl/P0267_RefImpl/coregraphics/xio2d_cg_main.h
@@ -470,6 +470,6 @@ struct surfaces {
 #include "xio2d_cg_paths.h"
 #include "xio2d_cg_paths_figures.h"
 #include "xio2d_cg_surface_state_props.h"
-#include "xio2d_cg_output_surfaces.h"
+//#include "xio2d_cg_output_surfaces.h"
 
 #endif // _IO2D_CG_MAIN_H_


### PR DESCRIPTION
I have updated the build scripts to allow painless consumption of this library via `find_package`. CMake doesn't allow to specify parent directory as include directory when exporting targets and backend targets used it so I had to refactor a lot.

Here are the new targets:
* `io2d_core` - backendless files. Users should not link to it directly.
* `io2d_cairo` - a Cairo meta-backend. Depends on `io2d_core` Contains Cairo files. Users shouldn't link to it.
* `io2d_coregraphics` - a CoreGraphics meta-backend. Depends on `io2d_core` Contains CoreGraphics files. Users shouldn't link to it.
* `io2d_cairo_win32` - a Cairo/Win32 backend. Depends on `io2d_cairo`. Contains Win32 files. Users can link to it.
* `io2d_cairo_xlib` - a Cairo/Xlib backend. Depends on `io2d_cairo`. Contains Xlib files. Users can link to it.
* `io2d_coregraphics_mac` - a CoreGraphics/Mac backend. Depends on `io2d_coregraphics`. Contains MacOS files. Users can link to it.
* `io2d_coregraphics_ios` - a CoreGraphics/iOS backend. Depends on `io2d_coregraphics`. Contains iOS files. Users can link to it.
* `io2d` - an interface library that depends on all built backends. Used for backend abstraction. Most users should only link to it.

Here's how dependency graph looks on GNU/Linux when linking to `io2d`:
* `io2d` brings `io2d_cairo_xlib`.
* `io2d_cairo_xlib` brings `io2d_cairo`.
* `io2d_cairo` brings `io2d_core`.

I have added `CONSUMING.md` with example code for the users.

Finally, I removed C++17 as a global standard since I and other people may want to consume this library in C++2a code. Instead, all tragets set `cxx_std_17` as compile feature. This bumped minimum CMake version to 3.8 but I think this is reasonable for this library.

I only have access to GNU/Linux PCs so I could only test Cairo/Xlib backend. Others need to be tested. EDIT: Oh, right, there is CI, good.

Fixes #81.