### PR TITLE
fix -Wnarrowing warnings in sample-app

### DIFF
--- a/P0267_RefImpl/Samples/rocks_in_space/Maths.cpp
+++ b/P0267_RefImpl/Samples/rocks_in_space/Maths.cpp
@@ -20,8 +20,8 @@ float rocks_in_space::minimum_distance_from_line_segment(point_2d e1, point_2d e
 rocks_in_space::point_2d rocks_in_space::rotate(const point_2d& point, float theta, const point_2d& origin)
 {
 	const auto translation = point - origin;
-	const auto s = sin(theta);
-	const auto c = cos(theta);
+	const auto s = std::sin(theta);
+	const auto c = std::cos(theta);
 
 	return point_2d{ translation.x() * c - translation.y() * s, translation.x() * s + translation.y() * c } + origin;
 }

--- a/P0267_RefImpl/Samples/rocks_in_space/Maths.h
+++ b/P0267_RefImpl/Samples/rocks_in_space/Maths.h
@@ -61,12 +61,12 @@ inline float rocks_in_space::polar_2d::theta() const
 
 inline rocks_in_space::point_2d rocks_in_space::pol_to_car(const polar_2d& p)
 {
-	return{ p.r() * cos(p.theta()), p.r() * sin(p.theta()) };
+	return{ p.r() * std::cos(p.theta()), p.r() * std::sin(p.theta()) };
 }
 
 inline rocks_in_space::polar_2d rocks_in_space::car_to_pol(const point_2d& v)
 {
-	return{ v.magnitude(), atan2(v.y(), v.x()) };
+	return{ v.magnitude(), std::atan2(v.y(), v.x()) };
 }
 
 inline rocks_in_space::stadium::stadium(point_2d c1, point_2d c2, float radius)


### PR DESCRIPTION
C-standard trigonometry functions in the global namespace, rather than C++-standard ones in the 'std' namespace, were getting used by rocks_in_space.  When passed in float values, the C versions will convert them to 'double's, whereas the C++ versions will retain 'float' or 'double'.  The use of the C versions, here, was leading to 'narrowing' warnings, whereby doubles were getting shortened to floats.  This may never have been noticed by the user, however, it did lead to compiler warnings (with Clang 6).

Switching rocks_in_space's warned calls to explicitly use math functions in the 'std' namespace (such as 'std::sin', 'std::cos', etc.) effectively fixes these warnings.