### PR TITLE
CMake: use find_package for Cairo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.0.0)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
 project(io2d CXX)
 if( MSVC )
 	if(CMAKE_C_FLAGS MATCHES "/W[0-4]")

--- a/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
@@ -24,37 +24,20 @@ target_compile_features(io2d_cairo PUBLIC cxx_std_17)
 target_link_libraries(io2d_cairo PUBLIC io2d_core)
 
 if(MSVC)
-	find_path(CAIRO_INCLUDE_DIR cairo.h)
 	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h)
-	find_library(CAIRO_LIB_DEBUG cairod)
-	find_library(CAIRO_LIB_RELEASE cairo)
 	find_library(GRAPHICSMAGICK_LIB graphicsmagick)
 elseif(APPLE)
-	find_path(CAIRO_INCLUDE_DIR cairo-xlib.h PATH_SUFFIXES cairo)
 	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h PATH_SUFFIXES GraphicsMagick)
-	find_library(CAIRO_LIB cairo)
 	find_library(GRAPHICSMAGICK_LIB GraphicsMagick)
 else() # Linux
-	find_path(CAIRO_INCLUDE_DIR cairo-xlib.h PATH_SUFFIXES cairo)
 	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h PATH_SUFFIXES GraphicsMagick)
-	find_library(CAIRO_LIB cairo)
 	find_library(GRAPHICSMAGICK_LIB GraphicsMagick)
 endif()
 
-target_include_directories(io2d_cairo SYSTEM PUBLIC ${CAIRO_INCLUDE_DIR} ${GRAPHICSMAGICK_INCLUDE_DIR})
+target_include_directories(io2d_cairo SYSTEM PUBLIC ${CAIRO_INCLUDE_DIRS} ${GRAPHICSMAGICK_INCLUDE_DIR})
 
-target_link_libraries(io2d_cairo PUBLIC ${GRAPHICSMAGICK_LIB})
+target_link_libraries(io2d_cairo PUBLIC ${CAIRO_LIBRARIES} ${GRAPHICSMAGICK_LIB})
 
-if(MSVC)
-	if(CAIRO_LIB_DEBUG STREQUAL "CAIRO_LIB_DEBUG-NOTFOUND")
-		message(STATUS "io2d: Can't find Debug build of Cairo. Will try to use Release build, instead.")
-		target_link_libraries(io2d_cairo PUBLIC ${CAIRO_LIB_RELEASE})
-	else()
-		target_link_libraries(io2d_cairo PUBLIC debug ${CAIRO_LIB_DEBUG} optimized ${CAIRO_LIB_RELEASE})
-	endif()
-else()
-	target_link_libraries(io2d_cairo PUBLIC ${CAIRO_LIB})
-endif()
 
 install(
 	TARGETS io2d_cairo EXPORT io2d_targets

--- a/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.8)
 
 project(io2d CXX)
 
+find_package(Cairo REQUIRED)
+
 add_library(io2d_cairo
 	cairo_renderer-graphicsmagickinit.cpp
 	xcairo.h

--- a/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
+++ b/P0267_RefImpl/P0267_RefImpl/cairo/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(io2d_cairo PUBLIC
 
 target_compile_features(io2d_cairo PUBLIC cxx_std_17)
 
-target_link_libraries(io2d_cairo PUBLIC io2d_core)
+target_link_libraries(io2d_cairo PUBLIC io2d_core Cairo::Cairo)
 
 if(MSVC)
 	find_path(GRAPHICSMAGICK_INCLUDE_DIR magick/api.h)
@@ -36,9 +36,9 @@ else() # Linux
 	find_library(GRAPHICSMAGICK_LIB GraphicsMagick)
 endif()
 
-target_include_directories(io2d_cairo SYSTEM PUBLIC ${CAIRO_INCLUDE_DIRS} ${GRAPHICSMAGICK_INCLUDE_DIR})
+target_include_directories(io2d_cairo SYSTEM PUBLIC ${GRAPHICSMAGICK_INCLUDE_DIR})
 
-target_link_libraries(io2d_cairo PUBLIC ${CAIRO_LIBRARIES} ${GRAPHICSMAGICK_LIB})
+target_link_libraries(io2d_cairo PUBLIC ${GRAPHICSMAGICK_LIB})
 
 
 install(

--- a/cmake/FindCairo.cmake
+++ b/cmake/FindCairo.cmake
@@ -1,0 +1,75 @@
+# - Try to find Cairo
+# Once done, this will define
+#
+#  CAIRO_FOUND - system has Cairo
+#  CAIRO_INCLUDE_DIRS - the Cairo include directories
+#  CAIRO_LIBRARIES - link these to use Cairo
+#
+# Copyright (C) 2012 Raphael Kubo da Costa <rakuco@webkit.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+pkg_check_modules(PC_CAIRO QUIET cairo)
+
+find_path(CAIRO_INCLUDE_DIRS
+    NAMES cairo.h
+    HINTS ${PC_CAIRO_INCLUDEDIR}
+          ${PC_CAIRO_INCLUDE_DIRS}
+    PATH_SUFFIXES cairo
+)
+
+find_library(CAIRO_LIBRARIES
+    NAMES cairo
+    HINTS ${PC_CAIRO_LIBDIR}
+          ${PC_CAIRO_LIBRARY_DIRS}
+)
+
+if (CAIRO_INCLUDE_DIRS)
+    if (EXISTS "${CAIRO_INCLUDE_DIRS}/cairo-version.h")
+        file(READ "${CAIRO_INCLUDE_DIRS}/cairo-version.h" CAIRO_VERSION_CONTENT)
+
+        string(REGEX MATCH "#define +CAIRO_VERSION_MAJOR +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        set(CAIRO_VERSION_MAJOR "${CMAKE_MATCH_1}")
+
+        string(REGEX MATCH "#define +CAIRO_VERSION_MINOR +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        set(CAIRO_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+        string(REGEX MATCH "#define +CAIRO_VERSION_MICRO +([0-9]+)" _dummy "${CAIRO_VERSION_CONTENT}")
+        set(CAIRO_VERSION_MICRO "${CMAKE_MATCH_1}")
+
+        set(CAIRO_VERSION "${CAIRO_VERSION_MAJOR}.${CAIRO_VERSION_MINOR}.${CAIRO_VERSION_MICRO}")
+    endif ()
+endif ()
+
+if ("${Cairo_FIND_VERSION}" VERSION_GREATER "${CAIRO_VERSION}")
+    message(FATAL_ERROR "Required version (" ${Cairo_FIND_VERSION} ") is higher than found version (" ${CAIRO_VERSION} ")")
+endif ()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Cairo REQUIRED_VARS CAIRO_INCLUDE_DIRS CAIRO_LIBRARIES
+                                        VERSION_VAR CAIRO_VERSION)
+
+mark_as_advanced(
+    CAIRO_INCLUDE_DIRS
+    CAIRO_LIBRARIES
+)


### PR DESCRIPTION
Use CMake's find_package to find Cairo, via (in part) a FindCairo.cmake file created by the WebKit team.