### PR TITLE
Adding the command [sudo make install] to complete the instalation of Cairo/Xlib on Linux

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -91,6 +91,7 @@ mkdir Debug
 cd Debug
 cmake --config Debug "-DCMAKE_BUILD_TYPE=Debug" ..
 cmake --build .
+sudo make install
 ```
 
 ### Cairo/Xlib on macOS


### PR DESCRIPTION
Adding the command **_sudo make install_** to complete the instalation of Cairo/Xlib on Linux.